### PR TITLE
[fix] deleteコマンドのhelpの解説がremoveになっていたので修正

### DIFF
--- a/ConsoleTodo/Commands/DeleteCommand.cs
+++ b/ConsoleTodo/Commands/DeleteCommand.cs
@@ -32,7 +32,7 @@ namespace ConsoleTodo.Command {
         }
 
         public override string GetHelp() {
-            return "削除 : remove [taskno] ..";
+            return "削除 : delete [taskno] ..";
         }
     }
 }


### PR DESCRIPTION
ヘルプの修正