### PR TITLE
[refactoring] 表示処理をエントリーポイントから切り出し

### DIFF
--- a/ConsoleApp/Program.cs
+++ b/ConsoleApp/Program.cs
@@ -2,6 +2,7 @@
 using ConsoleTodo;
 using ConsoleTodo.Command;
 using ConsoleTodo.Command.Result;
+using ConsoleTodo.Display;
 using ConsoleTodo.FileIO;
 
 Todo todo = new Todo();
@@ -9,6 +10,8 @@ Todo todo = new Todo();
 bool isLoop = true;
 
 IFileIO fileIO = new TaskFileIO();
+
+IDisplay display = new ConsoleDisplay();
 
 //  タスクを読み込んで追加しておく
 var tasks = fileIO.Load();
@@ -55,21 +58,13 @@ while (isLoop) {
     //  成功していたら保存
     if(result is SuccesTodoCommandResult succesResult) {
         List<TodoTask> resultTasks = succesResult.GetTodoCommandResult();
-        OutPutTaskList(resultTasks);
+        display.PrintTasks(resultTasks);
         fileIO.Save(todo.GetAllTasks());
     }
 
     //  失敗の場合
     if (result is ErrorCommandResult) {
-        Console.WriteLine(result.GetResultMessage());
-    }
-}
-
-void OutPutTaskList(List<TodoTask> tasks) {
-    int No = 0;
-    foreach (TodoTask task in tasks) {
-        Console.WriteLine(No + ":" + task.ToString());
-        No++;
+        display.PrintError(result);
     }
 }
 

--- a/ConsoleTodo/ConsoleTodo.csproj
+++ b/ConsoleTodo/ConsoleTodo.csproj
@@ -63,6 +63,8 @@
     <Compile Include="Commands\UpdateCommand.cs" />
     <Compile Include="Commands\Result\ICommandResult.cs" />
     <Compile Include="Commands\ICommandHelpProvider.cs" />
+    <Compile Include="Display\ConsoleDisplay.cs" />
+    <Compile Include="Display\IDisplay.cs" />
     <Compile Include="FileIO\IFileIO.cs" />
     <Compile Include="TodoTasks\ITodo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/ConsoleTodo/Display/ConsoleDisplay.cs
+++ b/ConsoleTodo/Display/ConsoleDisplay.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConsoleTodo.Display {
+    public class ConsoleDisplay : IDisplay {
+        public void PrintError(ICommandResult result) {
+            Console.WriteLine(result.GetResultMessage());
+        }
+
+        public void PrintTasks(List<TodoTask> tasks) {
+            int No = 0;
+            foreach (TodoTask task in tasks) {
+                Console.WriteLine(No + ":" + task.ToString());
+                No++;
+            }
+        }
+    }
+}

--- a/ConsoleTodo/Display/IDisplay.cs
+++ b/ConsoleTodo/Display/IDisplay.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConsoleTodo.Display {
+    public interface IDisplay {
+        void PrintTasks(List<TodoTask> tasks);
+        void PrintError(ICommandResult result);
+    }
+}

--- a/Test/ConsoleDisplay.cs
+++ b/Test/ConsoleDisplay.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test {
+    public class ConsoleDisplay {
+        //  表示周りのテストは、見た目でチェックできることが多いので、目視テストになっていることが多い
+    }
+}


### PR DESCRIPTION
## 変更の概要

#16 

## なぜこの変更をするのか

表示処理がエントリーポイントにハードコードされていることで、拡張性が落ちるため

## やったこと

- [x] Displayインターフェイスを作成
- [x] Displayインターフェイスを実装したConsoleDisplayクラスを作成

## 影響範囲

エントリーポイントの表示処理が抽象化されている
