### PR TITLE
[enhancement] コンソールのlist,donelistの出力形式を表形式に改修

### DIFF
--- a/ConsoleTodo/Display/ConsoleDisplay.cs
+++ b/ConsoleTodo/Display/ConsoleDisplay.cs
@@ -11,11 +11,44 @@ namespace ConsoleTodo.Display {
         }
 
         public void PrintTasks(List<TodoTask> tasks) {
-            int No = 0;
-            foreach (TodoTask task in tasks) {
-                Console.WriteLine(No + ":" + task.ToString());
-                No++;
+            int nameMaxLength = 0;
+            if (0 < tasks.Count) {
+                nameMaxLength = tasks.Max(t => GetDisplayLength(t.ToString()));
             }
+
+            string name = "Name";
+            string header = $"| No | {name.PadRight(nameMaxLength)} |";
+
+            string separator = new string('=', header.Length);
+
+            Console.WriteLine(separator);
+            Console.WriteLine(header);
+            Console.WriteLine(separator);
+
+            for (int i = 0; i < tasks.Count; i++) {
+                string paddedName = PadRightConsideringFullWidth(tasks[i].ToString(), nameMaxLength);
+                Console.WriteLine("| {0} | {1} |", i.ToString().PadRight(2), paddedName);
+            }
+
+            Console.WriteLine(separator);
+        }
+
+        private string PadRightConsideringFullWidth(string s, int totalWidth) {
+            int currentWidth = GetDisplayLength(s);
+            int diff = totalWidth - currentWidth;
+            return s + new string(' ', diff);
+        }
+
+        private int GetDisplayLength(string s) {
+            int length = 0;
+            foreach (char c in s) {
+                if ((c >= 0x00 && c < 0x81) || (c == 0xf8f0) || (c >= 0xff61 && c < 0xffa0) || (c >= 0xf8f1 && c < 0xf8f4)) {
+                    length += 1;  // 半角文字
+                } else {
+                    length += 2;  // 全角文字
+                }
+            }
+            return length;
         }
     }
 }


### PR DESCRIPTION
## 変更の概要

#10 

## なぜこの変更をするのか

コンソールにタスクを出力するときに、タスクの表示が見づらかったので、見やすいようにしたい

## やったこと

- [x] 行区切りで出力していたコンソールのPrint処理を、罫線を追加して出力するように変更

## 変更内容

表のような罫線を追加して見やすくした

```bash
================================================
| No | Name                                    |
================================================
| 0  | issueの定型文をすぐに出るように追加する    |
| 1  | test                                    |
| 2  | test1                                   |
| 3  | test                                    |
| 4  | test                                    |
| 5  | test                                    |
| 6  | testtest                                |
================================================
```

## どうやるのか

- list,donelistコマンドを使うと変更が確認できる